### PR TITLE
Changes to pacakge.json

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,7 +29,7 @@ Prerequisites: Node.js, npm
 1. Install nwjs: `npm install nw`
 2. `npm install`
 3. `npm install bower`
-4. `cd interface/ ; bower install ; cd ..`
+4. `npm run build:gmc`
 3. `nw .`
 
 ## Creating an executable/dmg/binary for your platform

--- a/package.json
+++ b/package.json
@@ -2,9 +2,14 @@
   "name": "Musicoin-wallet",
   "version": "1.0.0",
   "license": "MIT",
-  "private": true,
+  "private": false,
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/Musicoin/desktop.git"
+  },
   "node-main": "./hub/msc.js",
   "main": "./interface/index.html",
+  "bugs": "https://github.com/Musicoin/desktop/issues",
   "window": {
     "frame": true,
     "toolbar": true,
@@ -36,6 +41,7 @@
   "scripts": {
     "snyk-protect": "snyk protect",
     "prepare": "npm run snyk-protect",
+    "build:gmc": "git clone https://github.com/musicoin/go-musicoin gmc && cd gmc && make gmc",
     "test": "snyk test"
   },
   "snyk": true


### PR DESCRIPTION
Update package.json

Added bugs section
Changed repo status from private to public

Update package.json

Implements #215 - This still does assume Git and Go are both present. Until go-musicoin updates; we have to insist the person have go 1.9 or lower. The detection thinks 1.10 is 1.1. And no breaking change, so 2.x can't be allowed.

Update README.md

adds a step for build:gmc; removes manual steps

Package.json typo